### PR TITLE
checkmd: detect and error on links to README.md

### DIFF
--- a/checkmd
+++ b/checkmd
@@ -22,6 +22,14 @@ sub check {
         my $line = $_;
         chomp $line;
 
+        if($line =~ /\]\(([^)]*)/) {
+            my $target = $1;
+            if($target =~ /README.md$/) {
+                error($f, $line, $l, "Link to README.md: $target");
+            }
+        }
+
+        
         if($next_line_should_be_blank) {
             if(! ($line =~ m/^[\s]*$/)) {
                 error($f, $line, $l, "The line after a '#' header should be blank.");

--- a/usingcurl/uploads.md
+++ b/usingcurl/uploads.md
@@ -30,7 +30,7 @@ The upload kind is usually done with the `-d` or `--data` options, but there
 are a few additional alterations.
 
 Read the detailed description on how to do this with curl in the
-[HTTP POST with curl](../http/post/README.md) chapter.
+[HTTP POST with curl](../http/post/) chapter.
 
 ### multipart formpost
 
@@ -72,7 +72,7 @@ you have used locally, you specify it in the URL:
 
     curl -T uploadthis ftp://example.com/this/directory/remotename
 
-Learn much more about FTPing in the [FTP with curl](../ftp/README.md) section.
+Learn much more about FTPing in the [FTP with curl](../ftp/) section.
 
 ## SMTP uploads
 


### PR DESCRIPTION
Since mdBook turns them into 'index.html' they break the HTML version.