### PR TITLE
Using ansi quotes in variables.md and CI bad-quote update

### DIFF
--- a/.github/scripts/check-quotes.pl
+++ b/.github/scripts/check-quotes.pl
@@ -1,5 +1,8 @@
 #!/usr/bin/perl -w
 
+use utf8;
+use open qw(:std :utf8);
+
 my $sum = shift @ARGV;
 
 # Figure out all files in right order
@@ -29,6 +32,10 @@ sub check {
         }
         elsif(/^    / && (length($_)>79)) {
             print STDERR "$f:$l:1: woo wide quoted line, please wrap\n";
+            $errors++;
+        }
+        if(/^    .*[“”’]/) {
+            print STDERR "$f:$l:1: unicode quotes, please change to ansi\n";
             $errors++;
         }
         $l++;

--- a/cmdline/variables.md
+++ b/cmdline/variables.md
@@ -124,7 +124,7 @@ Expands the variable without leading and trailing white space. White space is de
 
 This is extra useful when reading data from files.
 
-    --expand-url “https://example.com/{{path:trim}}”
+    --expand-url "https://example.com/{{path:trim}}"
 
 ## Function: `json`
 
@@ -146,22 +146,22 @@ function ensures that all output characters are legal within a URL and the
 rest are encoded as `%HH` where `HH` is a two-digit hexadecimal number for the
 ascii value.
 
-    --expand-data “varName={{varName:url}}”
+    --expand-data "varName={{varName:url}}"
 
 To trim the variable first, apply both functions (in this order):
 
-    --expand-data “varName={{varName:trim:url}}”
+    --expand-data "varName={{varName:trim:url}}"
 
 ## Function: `b64`
 
 Expands the variable base64 encoded. Base64 is an encoding for binary data
 that only uses 64 specific characters.
 
-    --expand-data “content={{value:b64}}”
+    --expand-data "content={{value:b64}}"
     
 To trim the variable first, apply both functions (in this order):
 
-    --expand-data “content={{value:trim:b64}}”
+    --expand-data "content={{value:trim:b64}}"
 
 Example: get the contents of a file called `$HOME/.secret` into a variable
 called `fix`. Make sure that the content is trimmed and percent-encoded sent

--- a/cmdline/variables.md
+++ b/cmdline/variables.md
@@ -88,7 +88,7 @@ assign variables to the contents of other variables.
 
     curl \
         --expand-variable var1={{var2}} \
-        --expand-variable fullname=’Mrs {{first}} {{last}}’ \
+        --expand-variable fullname="Mrs {{first}} {{last}}" \
         --expand-variable source@{{filename}}
 
 Or done in a config file:


### PR DESCRIPTION
I was reading the doc https://ec.haxx.se/cmdline/variables.html and I was suprised to see unicode quotes in the command line examples:

![Screen Shot 2024-05-25 at 10 10 07](https://github.com/curl/everything-curl/assets/47263/156dace7-9b7a-4c03-923b-5149d68fa166)

I've checked it with the latest version of curl and such usage gives an error:

```
bessarabov@bessarabov-osx:~$ docker run -it --rm docker.io/curlimages/curl --expand-url “https://example.com/{{path:trim}}”
Warning: The argument '“https://example.com/”' starts with a unicode quote
Warning: where maybe an ASCII " was intended?
curl: (3) URL rejected: Port number was not a decimal number between 0 and 65535
bessarabov@bessarabov-osx:~$
```

So I'm pretty sure that this is a misspell in the docs that should be fixed.


PS I don't think that the exact curl version will give any additional info, but just in case i'm providing it here.


```
bessarabov@bessarabov-osx:~$ docker run -it --rm docker.io/curlimages/curl --version
curl 8.8.0 (x86_64-pc-linux-musl) libcurl/8.8.0 OpenSSL/3.1.5 zlib/1.3.1 brotli/1.1.0 libidn2/2.3.4 libpsl/0.21.2 libssh2/1.11.0 nghttp2/1.58.0
Release-Date: 2024-05-22
Protocols: dict file ftp ftps gopher gophers http https imap imaps ipfs ipns mqtt pop3 pop3s rtsp scp sftp smb smbs smtp smtps telnet tftp
Features: alt-svc AsynchDNS brotli GSS-API HSTS HTTP2 HTTPS-proxy IDN IPv6 Kerberos Largefile libz NTLM PSL SPNEGO SSL threadsafe TLS-SRP UnixSockets
bessarabov@bessarabov-osx:~$
bessarabov@bessarabov-osx:~$ docker images|grep curl
curlimages/curl              latest    bef568b8a706   3 days ago      23.5MB
bessarabov@bessarabov-osx:~$
```



