### PR TITLE
usingcurl/connections/README.md: rephrase without being TCP specific

### DIFF
--- a/usingcurl/connections/README.md
+++ b/usingcurl/connections/README.md
@@ -1,9 +1,9 @@
 # Connections
 
-Most of the protocols you use with curl speak TCP. With TCP, a client such as
-curl must first figure out the IP address(es) of the host you want to
+Most of the URLs you use with curl have a hostname and involve communication
+over IP. curl must first figure out the IP address(es) of the host you want to
 communicate with, then connect to it. "Connecting to it" means performing a
-TCP protocol handshake.
+protocol handshake.
 
 For ordinary command line usage, operating on a URL, these are details which
 are taken care of under the hood, and which you can mostly ignore. But at times


### PR DESCRIPTION
Since curl can also use UDP and QUIC.