### PR TITLE
usingcurl/downloads/whatis.md: remove "exactly" from title

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -82,7 +82,7 @@
     * [Trace options](usingcurl/verbose/trace.md)
     * [Write out](usingcurl/verbose/writeout.md)
   * [Downloads](usingcurl/downloads/README.md)
-    * [What exactly is downloading?](usingcurl/downloads/whatis.md)
+    * [What is downloading?](usingcurl/downloads/whatis.md)
     * [Storing downloads](usingcurl/downloads/storing.md)
     * [Download to a file named by the URL](usingcurl/downloads/url-named.md)
     * [Use the target filename from the server](usingcurl/downloads/content-disp.md)

--- a/usingcurl/downloads/whatis.md
+++ b/usingcurl/downloads/whatis.md
@@ -1,4 +1,4 @@
-# What exactly is downloading?
+# What is downloading?
 
 You specify the resource to download by giving curl a URL. curl defaults to
 downloading a URL unless told otherwise, and the URL identifies what to


### PR DESCRIPTION
superfluous