### PR TITLE
Update "Transient error" definition to include HTTP codes `408` and `429`

### DIFF
--- a/usingcurl/downloads/retry.md
+++ b/usingcurl/downloads/retry.md
@@ -6,8 +6,8 @@ certain failed transfers.
 
 If a transient error is returned when curl tries to perform a transfer, it
 retries this number of times before giving up. Setting the number to 0 makes
-curl do no retries (which is the default). Transient error means either: a
-timeout, an FTP 4xx response code, an HTTP 429 response code or an HTTP 5xx 
+curl do no retries (which is the default). Transient error means either: a 
+timeout, an FTP 4xx response code or an HTTP 408, 429, 500, 502, 503 or 504 
 response code.
 
 ## Tweak your retries

--- a/usingcurl/downloads/retry.md
+++ b/usingcurl/downloads/retry.md
@@ -7,7 +7,8 @@ certain failed transfers.
 If a transient error is returned when curl tries to perform a transfer, it
 retries this number of times before giving up. Setting the number to 0 makes
 curl do no retries (which is the default). Transient error means either: a
-timeout, an FTP 4xx response code or an HTTP 5xx response code.
+timeout, an FTP 4xx response code, an HTTP 429 response code or an HTTP 5xx 
+response code.
 
 ## Tweak your retries
 


### PR DESCRIPTION
Related:

- https://github.com/curl/curl/issues/3794
- https://github.com/curl/curl/commit/f7f0b0012d42db74a293d4df19b39644015f1868

Fixes https://github.com/curl/everything-curl/issues/511.