### PR TITLE
proselint: trim the markdowns before running proselint

### DIFF
--- a/.github/scripts/cleanmd.pl
+++ b/.github/scripts/cleanmd.pl
@@ -1,0 +1,25 @@
+#!/usr/bin/env perl
+# Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+#
+# SPDX-License-Identifier: curl
+#
+# Input: a markdown file, it gets modified *in place*
+#
+# The main purpose is to strip off quotes, lines starting with four spaces,
+# so that the result can be run through proselint better.
+#
+
+my $f = $ARGV[0];
+
+open(F, "<$f") or die;
+
+while(<F>) {
+    $_ =~ s/^    .*//g;
+
+    push @out, $_;
+}
+close(F);
+
+open(O, ">$f") or die;
+print O @out;
+close(O);

--- a/.github/workflows/proselint.yml
+++ b/.github/workflows/proselint.yml
@@ -22,6 +22,9 @@ jobs:
     - name: install prereqs
       run: sudo apt-get install python3-proselint
 
+    - name: trim off quoted parts
+      run: find . -name "*.md" -print0 | xargs -0 -n1 .github/scripts/cleanmd.pl
+
     # config file help: https://github.com/amperser/proselint/
     - name: store proselint config
       run: |

--- a/libcurl-http/cookies.md
+++ b/libcurl-http/cookies.md
@@ -60,9 +60,8 @@ the semicolon separator.
 ## Import export
 
 The cookie in-memory store can hold a bunch of cookies, and libcurl offers
-very powerful ways for an application to play with them. You can set new
-cookies, you can replace an existing cookie and you can extract existing
-cookies.
+powerful ways for an application to play with them. You can set new cookies,
+you can replace an existing cookie and you can extract existing cookies.
 
 ### Add a cookie to the cookie store
 

--- a/usingcurl/smtp.md
+++ b/usingcurl/smtp.md
@@ -94,7 +94,7 @@ to the mail server at `mail.example.com`, use:
 
     curl smtp://mail.example.com/client.example.com
 
-## No MX lookup!
+## No MX lookup
 
 When you send email with an ordinary mail client, it first checks for an MX
 record for the particular domain you want to send email to. If you send an


### PR DESCRIPTION
Since the quoted parts generate too many false positives