### PR TITLE
Update progressmeter.md

### DIFF
--- a/cmdline/progressmeter.md
+++ b/cmdline/progressmeter.md
@@ -56,7 +56,7 @@ From left to right:
 | `%`                    | Percentage completed of the whole transfer                                                                                                        |
 | `Total`                | Total size of the whole expected transfer (if known)                                                                                              |
 | `%`                    | Percentage completed of the download                                                                                                              |
-| `Received`             | Currently downloaded number of bytes                                                                                                              |
+| `Received`             | Currently downloaded number of bytes (headers bytes are not included)                                                                             |
 | `%`                    | Percentage completed of the upload                                                                                                                |
 | `Xferd`                | Currently uploaded number of bytes                                                                                                                |
 | `Average Speed Dload`  | Average transfer speed of the entire download so far, in number of bytes per second                                                               |


### PR DESCRIPTION
From some tests I ran, it seems that the "Received" info doesn't include the bytes of the headers. Try: 
curl -i https://example.com/ | wc -c
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  1256  100  1256    0     0   2121      0 --:--:-- --:--:-- --:--:--  2118
1592

1592 i pretty much bigger than 1256