### PR TITLE
.htaccess: remove block-all-mixed-content from the CSP

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,6 +1,6 @@
 RedirectMatch "^/.git" https://everything.curl.dev/
 
-Header set Content-Security-Policy: "upgrade-insecure-requests; block-all-mixed-content; default-src 'none'; img-src 'self'; script-src 'unsafe-inline' 'self'; style-src 'unsafe-inline' 'self'; form-action 'self'; frame-ancestors 'none'; require-trusted-types-for 'script';"
+Header set Content-Security-Policy: "upgrade-insecure-requests; default-src 'none'; img-src 'self'; script-src 'unsafe-inline' 'self'; style-src 'unsafe-inline' 'self'; form-action 'self'; frame-ancestors 'none'; require-trusted-types-for 'script';"
 Header set Cross-Origin-Embedder-Policy: "require-corp"
 Header set Cross-Origin-Opener-Policy: "same-origin"
 Header set Cross-Origin-Resource-Policy: "same-origin"


### PR DESCRIPTION
It is officially deprecated and ignored by current browsers.

URL: https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/block-all-mixed-content

Ref: https://github.com/curl/curl-www/pull/614