### PR TITLE
remove all BearSSL references

### DIFF
--- a/build/autotools.md
+++ b/build/autotools.md
@@ -76,7 +76,6 @@ automatically check for OpenSSL, but modern versions do not.
 
  - AmiSSL: `--with-amissl`
  - AWS-LC: `--with-openssl`
- - BearSSL: `--with-bearssl`
  - BoringSSL: `--with-openssl`
  - GnuTLS: `--with-gnutls`
  - LibreSSL: `--with-openssl`

--- a/build/tls.md
+++ b/build/tls.md
@@ -8,7 +8,6 @@ curl is written to work with a large number of TLS libraries:
 
  - AmiSSL
  - AWS-LC
- - BearSSL
  - BoringSSL
  - GnuTLS
  - libressl
@@ -77,15 +76,6 @@ configure detects Schannel in its default path by default.
 
 (WinSSL was previously an alternative name for Schannel, and earlier curl
 versions instead needed `--with-winssl`)
-
-### BearSSL
-
-    ./configure --with-bearssl
-
-configure detects BearSSL in its default path by default. You can optionally
-point configure to a custom install path prefix where it can find BearSSL:
-
-    ./configure --with-bearssl=/home/user/installed/bearssl
 
 ### Rustls
 

--- a/index-words
+++ b/index-words
@@ -136,7 +136,6 @@ apt
 Arch Linux
 AWS sigv4
 AWS-LC
-BearSSL
 bindings
 BoringSSL
 brotli

--- a/internals/tests/file-format.md
+++ b/internals/tests/file-format.md
@@ -413,7 +413,6 @@ feature is NOT required. If the feature is present then the test is SKIPPED.
 Features testable here are:
 
 - `alt-svc`
-- `bearssl`
 - `c-ares`
 - `cookies`
 - `crypto`

--- a/source/layout.md
+++ b/source/layout.md
@@ -54,7 +54,6 @@ table](https://curl.se/docs/ssl-compared.html) on the website to aid
 users.
 
 - AmiSSL: an OpenSSL fork made for AmigaOS (uses `openssl.c`)
-- BearSSL
 - BoringSSL: an OpenSSL fork maintained by Google. (uses `openssl.c`)
 - GnuTLS
 - LibreSSL: an OpenSSL fork maintained by the OpenBSD team. (uses `openssl.c`)

--- a/wordlist.txt
+++ b/wordlist.txt
@@ -32,7 +32,6 @@ backticks
 balancers
 Baratov
 BDFL
-BearSSL
 Benoit
 bitmask
 bitwise


### PR DESCRIPTION
Support was removed from curl in June 2025 in commit 08a3e8e19a59d1530bfb208e187ac7c34c978dfd